### PR TITLE
Update value_differentiable.rs

### DIFF
--- a/src/traits/value_differentiable.rs
+++ b/src/traits/value_differentiable.rs
@@ -1,8 +1,6 @@
 use crate::{KernelError, PositiveDefiniteKernel, Value};
 
-pub trait ValueDifferentiable<T>: PositiveDefiniteKernel<T>
-where
-    T: Value,
+pub trait ValueDifferentiable: PositiveDefiniteKernel<Vec<f64>>
 {
-    fn ln_diff_value(&self, params: &[f64], x: &T, xprime: &T) -> Result<(Vec<f64>, f64), KernelError>;
+    fn ln_diff_value(&self, params: &[f64], x: &Vec<f64>, xprime: &Vec<f64>) -> Result<(Vec<f64>, f64), KernelError>;
 }


### PR DESCRIPTION
このように変更すればいいのではないでしょうか
どうせTがVec<f64>なやつしかvalue微分できないのだから

※これマージしても色んな個所にエラー出るのでこれマージせずローカルで同じことやってください